### PR TITLE
chore: rm max multi-staked feature (per BSN)

### DIFF
--- a/deployments/rollup-bsn-demo/demo.sh
+++ b/deployments/rollup-bsn-demo/demo.sh
@@ -59,7 +59,7 @@ echo "  ✅ Finality contract deployed at: $finalityContractAddr"
 echo ""
 echo "🔗 Step 2: Registering consumer chain..."
 
-REGISTER_CMD="/bin/babylond --home /babylondhome tx btcstkconsumer register-consumer $CONSUMER_ID consumer-name consumer-description 2 $finalityContractAddr --from test-spending-key --chain-id $BBN_CHAIN_ID --keyring-backend test --fees 100000ubbn --output json -y"
+REGISTER_CMD="/bin/babylond --home /babylondhome tx btcstkconsumer register-consumer $CONSUMER_ID consumer-name consumer-description $finalityContractAddr --from test-spending-key --chain-id $BBN_CHAIN_ID --keyring-backend test --fees 100000ubbn --output json -y"
 echo "  → Command: $REGISTER_CMD"
 REGISTER_OUTPUT=$(docker exec babylondnode0 /bin/sh -c "$REGISTER_CMD")
 echo "  → Output: $REGISTER_OUTPUT"


### PR DESCRIPTION
- bumps babylon submodule to point to latest main
- fixes roll up demo script

Note
I tested the rollup demo on the latest main commit (which removed the BSN limit) - its working as expected.
cc @Vvaradinov - thanks for fixing stuff 👏 